### PR TITLE
Do not wipe out molder buffer

### DIFF
--- a/autoload/molder.vim
+++ b/autoload/molder.vim
@@ -36,7 +36,7 @@ function! molder#init() abort
 
   let b:molder_dir = l:dir
   setlocal modifiable
-  setlocal filetype=molder buftype=nofile bufhidden=wipe nobuflisted noswapfile
+  setlocal filetype=molder buftype=nofile bufhidden=unload nobuflisted noswapfile
   setlocal nowrap cursorline
   let l:files = map(readdirex(l:path, '1', {'sort': 'none'}), {_, v -> s:name(l:dir, v)})
   if !get(b:, 'molder_show_hidden', get(g:, 'molder_show_hidden', 0))


### PR DESCRIPTION
When opening a file or moving between directories, alternative file will be abandoned.
This PR fixes this behavior.

**before**

[![Image from Gyazo](https://i.gyazo.com/1a0158f367411ab0c7b4efa5c2375503.gif)](https://gyazo.com/1a0158f367411ab0c7b4efa5c2375503)

**after**

[![Image from Gyazo](https://i.gyazo.com/549bbe0deb356a89e32f2be5bfc8af5b.gif)](https://gyazo.com/549bbe0deb356a89e32f2be5bfc8af5b)
