### PR TITLE
Silence mappings

### DIFF
--- a/ftplugin/molder.vim
+++ b/ftplugin/molder.vim
@@ -1,8 +1,8 @@
-nnoremap <plug>(molder-open) :<c-u>call molder#open()<cr>
-nnoremap <plug>(molder-up) :<c-u>call molder#up()<cr>
-nnoremap <plug>(molder-reload) :<c-u>call molder#reload()<cr>
-nnoremap <plug>(molder-home) :<c-u>call molder#home()<cr>
-nnoremap <plug>(molder-toggle-hidden) :<c-u>call molder#toggle_hidden()<cr>
+nnoremap <silent> <plug>(molder-open) :<c-u>call molder#open()<cr>
+nnoremap <silent> <plug>(molder-up) :<c-u>call molder#up()<cr>
+nnoremap <silent> <plug>(molder-reload) :<c-u>call molder#reload()<cr>
+nnoremap <silent> <plug>(molder-home) :<c-u>call molder#home()<cr>
+nnoremap <silent> <plug>(molder-toggle-hidden) :<c-u>call molder#toggle_hidden()<cr>
 
 if !hasmapto('<plug>(molder-open)')
   nmap <buffer> <cr> <plug>(molder-open)


### PR DESCRIPTION
I feel it is a bit noisy that the following mappings echo the corresponding key sequences on the command line.

* `<plug>(molder-open)`
* `<plug>(molder-up)`
* `<plug>(molder-reload)`
* `<plug>(molder-home)`
* `<plug>(molder-toggle-hidden)`

I propose to silence these.