### PR TITLE
Implement keepalt feature

### DIFF
--- a/autoload/molder.vim
+++ b/autoload/molder.vim
@@ -1,3 +1,5 @@
+let g:molder_keepalt = get(g:, 'molder_keepalt', 0)
+
 function! s:sort(lhs, rhs) abort
   if a:lhs[-1:] ==# '/' && a:rhs[-1:] !=# '/'
     return -1
@@ -55,7 +57,7 @@ function! molder#init() abort
 endfunction
 
 function! molder#open() abort
-  exe 'edit' fnameescape(b:molder_dir .. substitute(getline('.'), '/$', '', ''))
+  exe (g:molder_keepalt ? 'keepalt' : '') 'edit' fnameescape(b:molder_dir .. substitute(getline('.'), '/$', '', ''))
 endfunction
 
 function! molder#up() abort
@@ -65,12 +67,12 @@ function! molder#up() abort
     return
   endif
   let l:dir = fnamemodify(l:dir, ':p:h:h:gs!\!/!')
-  exe 'edit' fnameescape(l:dir)
+  exe (g:molder_keepalt ? 'keepalt' : '') 'edit' fnameescape(l:dir)
   call search('\v^\V' .. escape(l:name, '\') .. '/\v$', 'c')
 endfunction
 
 function! molder#home() abort
-  exe 'edit' fnameescape(substitute(fnamemodify(expand('~'), ':p:gs!\!/!'), '/$', '', ''))
+  exe (g:molder_keepalt ? 'keepalt' : '') 'edit' fnameescape(substitute(fnamemodify(expand('~'), ':p:gs!\!/!'), '/$', '', ''))
 endfunction
 
 function! molder#reload() abort

--- a/doc/molder.txt
+++ b/doc/molder.txt
@@ -48,4 +48,14 @@ KEYMAPPINGS                                                 *molder-keymappings*
 * "<cr>" on directory: Go to the directory. <plug>(molder-open)
 
 ==============================================================================
+CONFIGURATION                                             *molder-configuration*
+
+                                                              *g:molder_keepalt*
+g:molder_keepalt
+  Default: 0
+  Set 1 to apply |:keepalt| to <plug>(molder-up), <plug>(molder-home) and
+  <plug>(molder-open). When you switch from file A to file B via molder
+  with these keys, file A becomes the |alternate-file|.
+
+==============================================================================
 vim:tw=78:ts=8:ft=help:norl:noet:fen:fdl=0:


### PR DESCRIPTION
Implemented "keepalt" feature. This is disabled by default.

If enabled, when switching from file A to file B via molder with molder's key mappings, file A becomes the `alternate-file`.

##  Disabled

https://user-images.githubusercontent.com/64692680/105049741-4f882b00-5ab0-11eb-99e6-50032ca0228a.mov


## Enabled


https://user-images.githubusercontent.com/64692680/105049771-59119300-5ab0-11eb-8d2e-59d0e5d3c56e.mov



