### PR TITLE
Not to create a swapfile when creating a buffer for a directory

### DIFF
--- a/autoload/molder.vim
+++ b/autoload/molder.vim
@@ -43,7 +43,7 @@ function! molder#init() abort
   endif
 
   let b:molder_dir = l:dir
-  noautocmd silent file `=b:molder_dir`
+  noautocmd noswapfile silent file `=b:molder_dir`
   setlocal modifiable
   setlocal filetype=molder buftype=nofile bufhidden=unload nobuflisted noswapfile
   setlocal nowrap cursorline


### PR DESCRIPTION
Currently, more than one vim instances cannot open the same directory without the following error:
```
E325: ATTENTION
Found a swap file by the name "~/.vimswap/.swp"
(...omitted)
```
This is because `:file` creates a swapfile by default.