### PR TITLE
Fix breaks alternate file when buffer name fix

### DIFF
--- a/autoload/molder.vim
+++ b/autoload/molder.vim
@@ -43,7 +43,7 @@ function! molder#init() abort
   endif
 
   let b:molder_dir = l:dir
-  noautocmd noswapfile silent file `=b:molder_dir`
+  noautocmd noswapfile keepalt silent file `=b:molder_dir`
   setlocal modifiable
   setlocal filetype=molder buftype=nofile bufhidden=unload nobuflisted noswapfile
   setlocal nowrap cursorline


### PR DESCRIPTION
Buffer name fix caused breaks alternate file. It occurs `reveal` is not work.
So I add `keepalt`.